### PR TITLE
Fixed issue with composer_home_path not defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ You can specify where is php with `env_proxy` variable. For example :
 
 You can also setup a global composer directory and make the bin directory available in the `$PATH` automatically by:
  
-    composer_home_path: /var/data/composer
     composer_path_env: true
+    composer_home_path: /opt/composer
+    composer_home_owner: root
+    composer_home_group: root
     composer_global_packages:
       phpunit/phpunit: "@stable"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,9 +3,9 @@
 composer_path: /usr/local/bin/composer
 composer_update: true
 composer_update_day: 20
-composer_home_path: ~
+composer_path_env: False
+#composer_home_path: /opt/composer
 composer_home_owner: root
 composer_home_group: root
-composer_path_env: False
 composer_global_packages: {}
 proxy_env: {}

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -2,12 +2,12 @@
 
 - name: Create composer home path
   file: path={{ composer_home_path }} state=directory owner={{ composer_home_owner }} group={{ composer_home_group }}
-  when: composer_home_path
+  when: composer_home_path is defined
 
 - name: Configure composer home path
   copy: dest=/etc/profile.d/composer-home.sh mode=0755
         content="export COMPOSER_HOME={{ composer_home_path}}\n"
-  when: composer_home_path
+  when: composer_home_path is defined
 
 - name: Configure composer path environment
   copy: dest=/etc/profile.d/composer-path.sh mode=0755
@@ -15,7 +15,8 @@
   when: composer_path_env
 
 - name: Global require packages
-  shell: composer global require {{ item.key }}:{{ item.value }} --no-progress
+  shell: COMPOSER_HOME={{ composer_home_path|default('~/.composer') }}
+         composer global require {{ item.key }}:{{ item.value }} --no-progress
          creates={{ composer_home_path|default('~/.composer') }}/vendor/{{ item.key }}
   with_dict: composer_global_packages
   when: composer_global_packages|length > 0


### PR DESCRIPTION
Related to pull request #7.

I had to fix an issue with composer_home_path is not defined.
Evaluating a string variabele to boolean seems to be a bad practise too.