### PR TITLE
move composer into place directly

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,12 +1,8 @@
 ---
 
-- name: Download and install Composer into the current directory.
+- name: Download and install Composer into the target directory.
   shell:
-    php -r "readfile('https://getcomposer.org/installer');" | php
+    php -r "readfile('https://getcomposer.org/installer');" |
+    php -- --install-dir={{ composer_path|dirname }} --filename={{ composer_path|basename }}
     creates={{ composer_path }}
   environment: proxy_env
-
-- name: Move Composer into bin directory.
-  shell:
-    mv composer.phar {{ composer_path }}
-    creates={{ composer_path }}


### PR DESCRIPTION
the composer installer allows you to specify the target location right away, without
the need to move it in a separate task