### PR TITLE
Add dependencies key in metadata

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -26,3 +26,4 @@ galaxy_info:
     - web
     - php
     - composer
+dependencies: []


### PR DESCRIPTION
Hello,

If this key not exists, an error occurs if we use this role into a requirement file (1.9.2) :

alexandre@xxxxxx $ sudo ansible-galaxy install -r requirements.yml
- executing: git clone https://github.com/kosssi/ansible-role-composer ansible-role-composer
- executing: git archive --prefix=ansible-role-composer/ --output=/tmp/tmpHtgjlk.tar HEAD
- extracting ansible-role-composer to /etc/ansible/roles/ansible-role-composer
- ansible-role-composer was installed successfully
Traceback (most recent call last):
  File "/usr/local/bin/ansible-galaxy", line 959, in <module>
    main()
  File "/usr/local/bin/ansible-galaxy", line 953, in main
    fn(args, options, parser)
  File "/usr/local/bin/ansible-galaxy", line 845, in execute_install
    role_dependencies = role_data['dependencies']
KeyError: 'dependencies'

