### PR TITLE
prevents deprecation warning

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -17,5 +17,5 @@
   shell: COMPOSER_HOME={{ composer_home_path|default('~/.composer') }}
          composer global require {{ item.key }}:{{ item.value }} --no-progress
          creates={{ composer_home_path|default('~/.composer') }}/vendor/{{ item.key }}
-  with_dict: composer_global_packages
+  with_dict: '{{ composer_global_packages }}'
   when: composer_global_packages|length > 0


### PR DESCRIPTION
[DEPRECATION WARNING]:
Using bare variables is deprecated. Update your 
playbooks so that the environment value uses the full variable syntax 
('{{composer_global_packages}}')
