### PR TITLE
Fix error in check run

### DIFF
--- a/tasks/update.yml
+++ b/tasks/update.yml
@@ -5,6 +5,7 @@
     date --date='{{ composer_update_day }} days ago' +'%s'
   register: composer_date
   changed_when: False
+  always_run: True
 
 - name: Update composer if necessary
   shell:


### PR DESCRIPTION
Ansible does not run shell and command  actions in "Check" mode, so no composer_date variable is registered at "Get date for composer update" step. At "Update composer if necessary" Ansible is not going to take any actions but still tries to evaluate "when" condition and fails:

```
TASK: [composer | Update composer if necessary] ******************************* 
fatal: [my_host] => error while evaluating conditional: composer_date.stdout|int > composer_stat.stat.mtime|int
```

Adding "always_run" to first task fixes the problem and does not break idempotency.

```
TASK: [composer | Get date for composer update] ******************************* 
ok: [my_host] => {"changed": false, "cmd": "date --date='20 days ago' +'%s'", "delta": "0:00:00.002436", "end": "2016-10-11 10:03:00.487436", "rc": 0, "start": "2016-10-11 10:03:00.485000", "stderr": "", "stdout": "1474452180", "stdout_lines": ["1474452180"], "warnings": []}
TASK: [composer | Update composer if necessary] ******************************* 
skipping: [my_host]
```
